### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=XinaBox
 maintainer=XinaBox <support@xinabox.cc>
 sentence=Simple library to interface PCA9685 LED Driver
 paragraph=Simple library to interface PCA9685 LED Driver
-category=Output
+category=Signal Input/Output
 url=https://github.com/xinabox/xOC05
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category 'Output' in library xOC05 is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format